### PR TITLE
Get rid of some clang warnings.

### DIFF
--- a/jpegoptim.c
+++ b/jpegoptim.c
@@ -330,7 +330,8 @@ int main(int argc, char **argv)
   jpeg_saved_marker_ptr cmarker; 
 
 
-  if (rcsid); /* so compiler won't complain about "unused" rcsid string */
+  if (rcsid)
+  ; /* so compiler won't complain about "unused" rcsid string */
 
   signal(SIGINT,own_signal_handler);
   signal(SIGTERM,own_signal_handler);
@@ -482,11 +483,11 @@ int main(int argc, char **argv)
        strncpy(tmpdir,dest_path,sizeof(tmpdir));
        strncpy(newname,dest_path,sizeof(newname));
        if (tmpdir[strlen(tmpdir)-1] != '/') {
-	 strncat(tmpdir,"/",sizeof(tmpdir)-strlen(tmpdir));
-	 strncat(newname,"/",sizeof(newname)-strlen(newname));
+	 strncat(tmpdir,"/",sizeof(tmpdir)-strlen(tmpdir)-1);
+	 strncat(newname,"/",sizeof(newname)-strlen(newname)-1);
        }
        strncat(newname,(char*)basename(argv[i]),
-	       sizeof(newname)-strlen(newname));
+	       sizeof(newname)-strlen(newname)-1);
      } else {
        if (!splitdir(argv[i],tmpdir,sizeof(tmpdir))) 
 	 fatal("splitdir() failed!");


### PR DESCRIPTION
Namely:

```
if statement has empty body [-Wempty-body]
  if (rcsid); /* so compiler won't complain about "unused" rcsid string */
```

```
the value of the size argument in 'strncat' is too large, might lead to a buffer overflow [-Wstrncat-size]
         strncat(tmpdir,"/",sizeof(tmpdir)-strlen(tmpdir));
```

---

Just followed clangs suggestions on how to fix these warnings:

```
jpegoptim.c:333:13: note: put the semicolon on a separate line to silence this warning
```

```
jpegoptim.c:485:22: note: change the argument to be the free space in the destination buffer minus the terminating null byte
         strncat(tmpdir,"/",sizeof(tmpdir)-strlen(tmpdir));
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                            sizeof(tmpdir) - strlen(tmpdir) - 1
```

gcc doesn't care about these changes/still compiles without warnings.
Compiles in gcc 4.7.2 and clang 3.2
Did a small test (on optimizing many pictures) and works as it should.
