### PR TITLE
Support building with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 2.8)
+project(jpegoptim)
+
+#Dependency on libJPEG.
+set(LIBJPEG_INCLUDE_DIR "" CACHE PATH "Path to directory containing header files of libJPEG (e.g. jpeglib.h).")
+set(LIBJPEG_LIBRARY_DIR "" CACHE FILEPATH "Path to static library file of libJPEG (e.g. libjpeg.a).")
+include_directories(${LIBJPEG_INCLUDE_DIR})
+add_library(libjpeg STATIC IMPORTED)
+set_target_properties(libjpeg PROPERTIES IMPORTED_LOCATION ${LIBJPEG_LIBRARY_DIR})
+
+#Source files.
+file(GLOB jpegoptim_SRC "*.c") #Adds all .c files in the source directory.
+
+#Header files.
+include_directories("${PROJECT_SOURCE_DIR}") #Adds all .h files in the source directory.
+
+#Build the binary!
+add_executable(jpegoptim ${jpegoptim_SRC})
+target_link_libraries(jpegoptim libjpeg)


### PR DESCRIPTION
This adds a CMake file for jpegoptim. This will hopefully make building a lot easier for many people, especially on other platforms than Linux.

I've tested this on two platforms:
On Windows 8.1, using CMake 3.2.3 and MinGW-w64 5.1.0, by linking it to Mozjpeg.
On Ubuntu 15.04, using CMake 3.4.3 and GCC 5.3.0, by linking it to Mozjpeg.

It has not been tested on OSX, but the functionality of this CMakeLists file is fairly basic so I won't expect any inconsistencies.

The program produced about 4% better compression than competitor jpegtran, so I'm pretty happy that I've made a working version now!