### PR TITLE
Fix --overwrite option

### DIFF
--- a/jpegoptim.c
+++ b/jpegoptim.c
@@ -97,6 +97,7 @@ struct option long_options[] = {
   {"dest",1,0,'d'},
   {"force",0,0,'f'},
   {"version",0,0,'V'},
+  {"overwrite",0,0,'o'},
   {"preserve",0,0,'p'},
   {"preserve-perms",0,0,'P'},
   {"strip-all",0,0,'s'},


### PR DESCRIPTION
The `--overwrite` option is mentioned in the `--help` output, but it does not exist.

    $ jpegoptim -dfoo -m10 --overwrite bar.jpg 
    jpegoptim: unrecognized option '--overwrite'
    bar.jpg 950x355 24bit JFIF  [OK] target file already exists!
