### PR TITLE
Use %d instead of %u for signed int.

### DIFF
--- a/jpegoptim.c
+++ b/jpegoptim.c
@@ -484,10 +484,10 @@ int main(int argc, char **argv)
     if (all_progressive) 
       fprintf(stderr,"All output files will be progressive\n");
     if (target_size > 0) 
-      fprintf(stderr,"Target size for output files set to: %u Kbytes.\n",
+      fprintf(stderr,"Target size for output files set to: %d Kbytes.\n",
 	      target_size);
     if (target_size < 0) 
-      fprintf(stderr,"Target size for output files set to: %u%%\n",
+      fprintf(stderr,"Target size for output files set to: %d%%\n",
 	      -target_size);
   }
 


### PR DESCRIPTION
This pull request fixes the following Cppcheck warning:
```
jpegoptim.c:487:7: warning: %u in format string (no. 1) requires 'unsigned int' but the argument type is 'signed int'. [invalidPrintfArgType_uint]
      fprintf(stderr,"Target size for output files set to: %u Kbytes.\n",
      ^
jpegoptim.c:490:7: warning: %u in format string (no. 1) requires 'unsigned int' but the argument type is 'signed int'. [invalidPrintfArgType_uint]
      fprintf(stderr,"Target size for output files set to: %u%%\n",
      ^
```