### PR TITLE
Preserve nanosecond timestamps if available.

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -22,6 +22,15 @@
 /* Define if you have labs function. */
 #undef HAVE_LABS
 
+/* Define if you have the fileno function. */
+#undef HAVE_FILENO
+
+/* Define if you have the utimensat function. */
+#undef HAVE_UTIMENSAT
+
+/* Define to 1 if `st_mtim' is a member of `struct stat'. */
+#undef HAVE_STRUCT_STAT_ST_MTIM
+
 /* Define if you have the <getopt.h> header file.  */
 #undef HAVE_GETOPT_H
 

--- a/configure
+++ b/configure
@@ -1940,6 +1940,63 @@ $as_echo "$ac_res" >&6; }
   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
 
 } # ac_fn_c_check_func
+
+# ac_fn_c_check_member LINENO AGGR MEMBER VAR INCLUDES
+# ----------------------------------------------------
+# Tries to find if the field MEMBER exists in type AGGR, after including
+# INCLUDES, setting cache variable VAR accordingly.
+ac_fn_c_check_member ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2.$3" >&5
+$as_echo_n "checking for $2.$3... " >&6; }
+if eval \${$4+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$5
+int
+main ()
+{
+static $2 ac_aggr;
+if (ac_aggr.$3)
+return 0;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  eval "$4=yes"
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$5
+int
+main ()
+{
+static $2 ac_aggr;
+if (sizeof ac_aggr.$3)
+return 0;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  eval "$4=yes"
+else
+  eval "$4=no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+eval ac_res=\$$4
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+
+} # ac_fn_c_check_member
 cat >config.log <<_ACEOF
 This file contains any messages produced by compilers while
 running configure, to aid debugging if configure makes a mistake.
@@ -3970,6 +4027,39 @@ _ACEOF
 
 fi
 done
+
+for ac_func in fileno
+do :
+  ac_fn_c_check_func "$LINENO" "fileno" "ac_cv_func_fileno"
+if test "x$ac_cv_func_fileno" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_FILENO 1
+_ACEOF
+
+fi
+done
+
+for ac_func in utimensat
+do :
+  ac_fn_c_check_func "$LINENO" "utimensat" "ac_cv_func_utimensat"
+if test "x$ac_cv_func_utimensat" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_UTIMENSAT 1
+_ACEOF
+
+fi
+done
+
+
+ac_fn_c_check_member "$LINENO" "struct stat" "st_mtim" "ac_cv_member_struct_stat_st_mtim" "$ac_includes_default"
+if test "x$ac_cv_member_struct_stat_st_mtim" = xyes; then :
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_STRUCT_STAT_ST_MTIM 1
+_ACEOF
+
+
+fi
 
 
 

--- a/configure
+++ b/configure
@@ -3316,6 +3316,7 @@ $as_echo "no" >&6; }
 fi
 
 
+CPPFLAGS="$CPPFLAGS -I. -I${srcdir}"
 
 
 # Check whether --with-libjpeg was given.

--- a/configure.in
+++ b/configure.in
@@ -15,6 +15,7 @@ AC_PROG_CC
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 
+CPPFLAGS="$CPPFLAGS -I. -I${srcdir}"
 
 AC_ARG_WITH(libjpeg, [  --with-libjpeg=DIR	  libjpeg is installed in ],
 	[if test $withval != yes; then

--- a/configure.in
+++ b/configure.in
@@ -63,6 +63,10 @@ AC_SUBST(GNUGETOPT)
 
 AC_CHECK_FUNCS(mkstemps)
 AC_CHECK_FUNCS(labs)
+AC_CHECK_FUNCS(fileno)
+AC_CHECK_FUNCS(utimensat)
+
+AC_CHECK_MEMBERS([struct stat.st_mtim])
 
 dnl own tests
 


### PR DESCRIPTION
jpegoptim's `-p` option currently only preserves timestamps at a 1-second resolution. This PR makes use of `stat.st_mtim` and `futimens()` to preserve nanosecond-resolution timestamps.