### PR TITLE
[Prevent NULL-ptr dereference] exit early if failed to read coefficients

### DIFF
--- a/jpegoptim.c
+++ b/jpegoptim.c
@@ -709,6 +709,8 @@ retry_point:
 		}
 	} else {
 		coef_arrays = jpeg_read_coefficients(&dinfo);
+        if (coef_arrays == NULL)
+            fatal("failed to read coefficients");
 	}
 
 	inpos=ftell(infile);


### PR DESCRIPTION
`jpeg_read_coefficients()` can return NULL under certain conditions. When this happens, the program would segfault later during the execution.

This fix checks if the return value of  `jpeg_read_coefficients()` is NULL and exits if its NULL.