### PR TITLE
Enforce LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
+# Enforce Unix newlines
+* text=auto eol=lf
+
 *.c	ident
 *.in	ident
 README	ident
-


### PR DESCRIPTION
On Windows `autocrlf` is `true` by default, so this makes sure LF is used everywhere regardless of OS