### PR TITLE
CI: ignore dependabot branches since it opens a PR

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,6 +1,9 @@
 name: compile
 on:
   push:
+    branches:
+      - "**"
+      - "!dependabot/**"
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Sorry, I missed this in #136 