### PR TITLE
Bring back `ubuntu:latest` testing

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: windows-latest
             triplet: x64-windows
@@ -44,6 +44,7 @@ jobs:
       # Gather documentation and executables to a common directory
       # Ignore copying errors from only one of build/jpegoptim or build/jpegoptim.exe existing
       - name: Prepare files
+        if: matrix.os != 'ubuntu-latest'
         run: |
           mkdir build/dist
           cp build/jpegoptim build/jpegoptim.exe COPYRIGHT LICENSE README build/dist/ 2>/dev/null || true
@@ -51,6 +52,7 @@ jobs:
 
       # Upload the compiled binary
       - uses: actions/upload-artifact@v3
+        if: matrix.os != 'ubuntu-latest'
         with:
           name: jpegoptim-${{ matrix.triplet }}
           path: build/dist

--- a/jpegoptim.c
+++ b/jpegoptim.c
@@ -244,7 +244,7 @@ void print_usage(void)
 		"                    keep old file if the gain is below a threshold (%%)\n"
 #ifdef PARALLEL_PROCESSING
 		"  -w<max>, --workers=<max>\n"
-		"                    set mximum number of parallel threads (default is 1)\n"
+		"                    set maximum number of parallel threads (default is 1)\n"
 #endif
 		"  -b, --csv         print progress info in CSV format\n"
 		"  -o, --overwrite   overwrite target file even if it exists (meaningful\n"


### PR DESCRIPTION
Following @XhmikosR comment ([here](https://github.com/tjko/jpegoptim/pull/146#discussion_r1167970598)).

We should probably keep on testing `ubuntu:latest` while only uploading the linux binary built using `ubuntu:20.04`.

Cheers