### PR TITLE
Fix parallel processing and reading file list looping infinitely

### DIFF
--- a/jpegoptim.c
+++ b/jpegoptim.c
@@ -1328,13 +1328,13 @@ int main(int argc, char **argv)
 			}
 			if (pipe(pipe_fd) < 0)
 				fatal("failed to open pipe");
-			if (files_from)
-				fflush(files_from);
 			pid = fork();
 			if (pid < 0)
 				fatal("fork() failed");
 			if (pid == 0) {
 				/* Child process starts here... */
+				if (files_from)
+					fclose(files_from);
 				close(pipe_fd[0]);
 				FILE *p;
 

--- a/jpegoptim.c
+++ b/jpegoptim.c
@@ -1328,6 +1328,8 @@ int main(int argc, char **argv)
 			}
 			if (pipe(pipe_fd) < 0)
 				fatal("failed to open pipe");
+			if (files_from)
+				fflush(files_from);
 			pid = fork();
 			if (pid < 0)
 				fatal("fork() failed");


### PR DESCRIPTION
This change `fflush`es `files_from` before `fork`ing.

Forking a process with open file streams requires that the stream be `fflush`ed before the `fork` (even read only streams). Otherwise when the child `exit()`s it will clobber the seek position of the stream in the parent process, often resulting in an infinite loop as the end of the file is never found.

Technical details at:
https://stackoverflow.com/questions/50110992/why-does-forking-my-process-cause-the-file-to-be-read-infinitely/50112169#50112169