### PR TITLE
Minor inconvinience

### DIFF
--- a/jpegoptim.c
+++ b/jpegoptim.c
@@ -241,9 +241,9 @@ METHODDEF(void) my_output_message (j_common_ptr cinfo)
 
 void print_usage(void)
 {
-	fprintf(stderr,PROGRAMNAME " v" VERSION "  " COPYRIGHT "\n");
+	fprintf(stdout,PROGRAMNAME " v" VERSION "  " COPYRIGHT "\n");
 
-	fprintf(stderr,
+	fprintf(stdout,
 		"Usage: " PROGRAMNAME " [options] <filenames> \n\n"
 		"  -d<path>, --dest=<path>\n"
 		"                    specify alternative destination directory for \n"


### PR DESCRIPTION
It is inconvenient when we can not `prog --help | grep blah`, have to redirect `jpegoptim --help 2>&1 | grep loss`

and this says so https://www.gnu.org/prep/standards/html_node/_002d_002dhelp.html